### PR TITLE
fix: Account for duplicate letters in formatRow

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -31,28 +31,28 @@ function getTodaysWord() {
 }
 
 function formatRow(word, row) {
-    let new_row = [];
+    const wordLetters = Array.from(word);
+    const rowLetters = row.map((tile) => tile.letter);
+    const newRow = row.map((tile) => ({
+        state: "incorrect",
+        letter: tile.letter,
+    }));
     for (let i = 0; i < row.length; i++) {
         let tile = row[i];
         if (word[i] === tile.letter) {
-            new_row.push({
-                state: "correct",
-                letter: tile.letter,
-            });
-        } else if (word.indexOf(tile.letter) !== -1) {
-            new_row.push({
-                state: "partial",
-                letter: tile.letter,
-            })
-        } else {
-            new_row.push({
-                state: "incorrect",
-                letter: tile.letter,
-            })
+            newRow[i].state = "correct";
+            wordLetters[i] = null;
+            rowLetters[i] = null;
         }
     }
-    
-    return new_row;
+    for (let i = 0; i < row.length; i++) {
+        let tile = row[i];
+        if (rowLetters[i] !== null && wordLetters.indexOf(tile.letter) !== -1) {
+            newRow[i].state = "partial";
+            wordLetters[wordLetters.indexOf(tile.letter)] = null;
+        }
+    }    
+    return newRow;
 }
 
 export { initBoard, getTodaysWord, formatRow, getWordByDayId, daysPassed };


### PR DESCRIPTION
This fixes the algorithm for coloring the row to account for duplicates.

Example:

(`i` = incorrect, `p` = partial, `c` = correct)

If the answer is `THOSE`, and `GEESE` is guessed, the result should be `iiicc` since the E in the last position is used when calculating the green squares, the E's in the middle do not count as partial matches. (Currently the algorithm instead would respond `ippcc`)

If the answer is `DREAD`, and `ADDED` is guessed, the result should be `ppipc` since the D in the last position needs to be green, and only *one* of the other D's should be marked partial since the word is missing the letter R (Currently the algorithm instead would respond `ppppc`, implying that no letters are missing)